### PR TITLE
Peer-to-peer connections (unencrypted) support finished

### DIFF
--- a/src/request_registry.h
+++ b/src/request_registry.h
@@ -8,13 +8,17 @@
 #include "registry.h"
 #include "stealthcom_user.h"
 
+#define OUTBOUND true
+#define INBOUND  false
+
 class RequestRegistryEntry {
 public:
     StealthcomUser* user;
     int ttl;
+    bool direction;
 
-    RequestRegistryEntry(StealthcomUser* u, int time_to_live)
-        : user(u), ttl(time_to_live) {}
+    RequestRegistryEntry(StealthcomUser* u, int time_to_live, bool direction)
+        : user(u), ttl(time_to_live), direction(direction) {}
 };
 
 class RequestRegistry : public Registry<RequestRegistryEntry> {
@@ -28,8 +32,9 @@ public:
     RequestRegistry();
     ~RequestRegistry();
 
-    void add_or_update_entry(const uint8_t* MAC);
+    void add_or_update_entry(const uint8_t* MAC, bool direction);
     std::vector<StealthcomUser*> get_requests();
+    bool has_active_request(const std::string& MAC);
 };
 
 extern std::shared_ptr<RequestRegistry> request_registry;

--- a/src/stealthcom_logic.cpp
+++ b/src/stealthcom_logic.cpp
@@ -56,7 +56,6 @@ void stealthcom_init(const char *netif) {
 void stealthcom_main_thread() {
     while(true) {
         std::string msg = input_queue->pop();
-
         state_machine->handle_input(msg);
     }
 

--- a/src/user_registry.h
+++ b/src/user_registry.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <atomic>
 #include "registry.h"
 #include "stealthcom_user.h"
 
@@ -21,6 +22,7 @@ public:
 class UserRegistry : public Registry<UserRegistryEntry> {
 private:
     std::unordered_map<std::string, UserRegistryEntry*> registry;
+    std::atomic<bool> users_protected;
 
 protected:
     void decrement_ttl_and_remove_expired() override;
@@ -32,6 +34,9 @@ public:
     void add_or_update_entry(const uint8_t* MAC, std::string user_ID);
     std::vector<StealthcomUser*> get_users();
     StealthcomUser * get_user(std::string& MAC);
+    void notify_connect(std::string& MAC);
+    void protect_users();
+    void unprotect_users();
 };
 
 extern std::shared_ptr<UserRegistry> user_registry;


### PR DESCRIPTION
- User registry no longer removes users if in SHOW_USERS or CONNECTION_REQUESTS substate
- Outbound connection requests prevent the target user from being erased by user_registry
- Connection requests can time out
- user_registry will wait to remove an entry if it is being used by request_registry