### PR TITLE
Minor detail change, call begin_connection() API upon successful key-ex rather than set connection state directly

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -579,7 +579,7 @@ void key_exchange_thread(StealthcomUser *user, bool initiator) {
 
     encryption_key = derive_encryption_key(shared_secret);
 
-    state_machine->set_connection_state(CONNECTED);
+    begin_connection(user);
     system_push_msg("Crypto: Key exchange complete - you may now securely exchange messages");
 
     user_registry->unprotect_users();

--- a/src/stealthcom_connection_logic.h
+++ b/src/stealthcom_connection_logic.h
@@ -5,6 +5,7 @@
 #include "packet_rx_tx.h"
 #include "stealthcom_user.h"
 
+void begin_connection(StealthcomUser *user);
 void connection_worker_init(std::shared_ptr<PacketQueue> queue);
 void connection_worker_thread();
 void send_conn_request(StealthcomUser *user);


### PR DESCRIPTION
The begin_connection() API sets the connection state to CONNECTED as well as notifies the user registry that the state has changed